### PR TITLE
Import ray_providers file into decorators package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 __pycache__
 venv
+.egg*
 venv/*
 README.html
 .DS_STORE

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ memory.To start, in your environment with ray installed, run:
 parameter as `task_args`, like:
 
     ```python
-    from ray_provider.decorators.ray_decorators import ray_task
+    from ray_provider.decorators import ray_task
 
     default_args = {
         'on_success_callback': RayBackend.on_success_callback,

--- a/ray_provider/decorators/__init__.py
+++ b/ray_provider/decorators/__init__.py
@@ -14,3 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+from .ray_decorators import ray_task


### PR DESCRIPTION
Creates a simpler path for importing the ray decorator. Now users just
need to write

```from ray_provider.decorators import ray_task```